### PR TITLE
localsettings.py.example: Fixed backend example values

### DIFF
--- a/xmppaccount/localsettings.py.example
+++ b/xmppaccount/localsettings.py.example
@@ -152,11 +152,11 @@ DEFAULT_XMPP_HOST = 'example.com'
 XMPP_BACKENDS = {
     'default': {
         'BACKEND': 'backends.ejabberd_xmlrpc.EjabberdXMLRPCBackend',
-        'HOST': '127.0.0.1',
+        'uri': 'http://127.0.0.1:4560',
         # If you have authentication defined for the xmlrpc API:
-        #'USER': '',
-        #'SERVER': '',
-        #'PASSWORD': '',
+        #'user': '',
+        #'server': '',
+        #'password': '',
     }
 }
 


### PR DESCRIPTION
The example values in localsettings.py.example for XMPP_BACKENDS is wrong. I got the following error with the example values and it took me some time to find the cause for it:
`Exception Value: __init__() got an unexpected keyword argument 'HOST'`

This PR fixes this.

Thank you for this project. It is much appreciated and works great :+1: 